### PR TITLE
REST Proxy Service Controller and Test outline added.

### DIFF
--- a/RESTProxy/README.md
+++ b/RESTProxy/README.md
@@ -53,7 +53,26 @@ open ./build/reports/jacoco/test/html/index.html
 ## POST a RESTProxy Request
 With the MongoDb and RESTProxy server launched as described above, perform a HTTP POST with a body JSON to the RESTProxy service endpoint to trigger a 3rd Party service and obtain a response. Various tools can be used for this 'PostMan' plugin for the Chrome browser is propular, however other tools exist such as 'curl' and 'wget'.  See below for an example of 'curl' POST'ing a logical request as a JSON body to the RESTProxy endpoint.
 ```
-curl -d '{"name": "GetUser", "qparam":[{"key":"userid", "value":"1"}]}' -H "Content-Type: application/json" -X POST http://localhost:8080/serviceproxy
+curl -v -d  '{"name": "GetUser", "qparam":[{"key":"userid", "value":"1"}]}' -H "Content-Type: application/json" -X POST http://localhost:8080/remoteservicegateway/proxyService
+```
+where the expected response should appear as:
+```
+*   Trying ::1...
+* TCP_NODELAY set
+* Connected to localhost (::1) port 8080 (#0)
+> POST /remoteservicegateway/proxyService HTTP/1.1
+> Host: localhost:8080
+> User-Agent: curl/7.54.0
+> Accept: */*
+> Content-Type: application/json
+> Content-Length: 61
+> 
+* upload completely sent off: 61 out of 61 bytes
+< HTTP/1.1 200 
+< Content-Length: 0
+< Date: Mon, 11 Feb 2019 12:30:51 GMT
+< 
+* Connection #0 to host localhost left intact
 ```
 
 ### Configuration overrides

--- a/RESTProxy/build.gradle
+++ b/RESTProxy/build.gradle
@@ -1,29 +1,53 @@
 buildscript {
-	ext {
-		springBootVersion = '2.1.2.RELEASE'
-	}
-	repositories {
-		mavenCentral()
-	}
+    ext {
+        springBootVersion = '2.0.5.RELEASE'
+    }
+    repositories {
+        mavenCentral()
+    }
 	dependencies {
-		classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
-	}
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
+    }
 }
 
+apply plugin: 'eclipse'
 apply plugin: 'java'
 apply plugin: 'org.springframework.boot'
 apply plugin: 'io.spring.dependency-management'
+apply plugin: 'jacoco'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '1.8'
 
+jacoco {
+    toolVersion = "0.7.6.201602180812"
+}
+jacocoTestReport{
+    reports {
+        xml.enabled false
+        csv.enabled false
+        html.enabled true
+    }
+}
+    
+compileJava.options.encoding = 'UTF-8'
+dependencies {
+    testCompile 'junit:junit:4.12'
+}
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    compile('org.springframework.boot:spring-boot-starter-data-mongodb')
+    compile('org.springframework.boot:spring-boot-starter-data-rest')
+    testCompile('org.springframework.boot:spring-boot-starter-test')
+	
+
+    //some common useful things
+    compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.5'
+    compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
+	
 }

--- a/RESTProxy/src/main/java/com/example/proxy/controller/ProxyServiceController.java
+++ b/RESTProxy/src/main/java/com/example/proxy/controller/ProxyServiceController.java
@@ -1,0 +1,70 @@
+package com.example.proxy.controller;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.proxy.dto.ProxyRequest;
+
+@RestController
+@RequestMapping("/remoteservicegateway") 
+            
+
+public class ProxyServiceController {
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    /**
+     * POST /remoteservicegateway/proxyService
+     *  Realy proxy Request onto external 3rd party service and respond
+     * 
+     *
+     * returns:
+     * HTTP 200  if 3rd party executed ok
+     * HTTP 400  if malformed Request
+     * HTTP 404  if remote service not found (consider time out)
+     * HTTP 503  if something when wrong... (i.e.no storage device)
+     * 
+     * @return
+     */
+    @RequestMapping(value = "/proxyService", method = RequestMethod.POST, headers="Accept=application/json")
+    public ResponseEntity<?> service(@RequestBody ProxyRequest proxyRequest) {
+        HttpStatus httpStatus = HttpStatus.OK;
+        ResponseEntity response = null;
+        String msg = "ok";
+        
+        try{
+            
+            // validate the proxy request
+            
+            // retrieve service mapping from persistent store
+            
+            // Engineer 3rd Party URL and invoke
+            
+            // manage the 3rd party response  ( 200, 40x & 50x) back ot client.
+        
+            
+            
+        } catch (IllegalArgumentException iae){
+            httpStatus = HttpStatus.BAD_REQUEST;   // http 400
+            msg = String.format("HTTPStatus:%s Unable to service proxy request.  %s",httpStatus, iae.getMessage() );
+            
+           
+        } catch( Throwable t){
+            httpStatus = HttpStatus.SERVICE_UNAVAILABLE;
+            msg = String.format("HTTPStatus:%s A serious error occured, attempting to service request. Logical Request: '%s'. Error: %s",httpStatus.toString(), proxyRequest.getName(), t.getMessage() );
+            
+             
+            
+        }finally {
+            logger.info( String.format("HTTPStatus:%s Serviced Proxy Request for logical service: '%s'", httpStatus.toString() , proxyRequest.getName() ) );
+        }
+        
+        // return the saved - new Policy - it has been enriched with stores new primary key
+        return new ResponseEntity<>(response, httpStatus);
+    }
+}

--- a/RESTProxy/src/main/java/com/example/proxy/dto/ProxyRequest.java
+++ b/RESTProxy/src/main/java/com/example/proxy/dto/ProxyRequest.java
@@ -1,0 +1,54 @@
+package com.example.proxy.dto;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * A simple Proxy service request Object.
+ * 
+ * A logical request object containing details of the request to be relayed onto the remote 3rd party service.
+ * 
+ * 
+ * @author gavinling
+ *
+ */
+public class ProxyRequest {
+    // Mandatory: logical proxy service name.  Resolves to persistent service profile.
+    private String name;
+    
+    // Optional: request object properties
+//    private ArrayList<header> headers = new ArrayList<>();
+//    private ArrayList<Queryparam> queryParams = new ArrayList<>();
+//    private String payload;
+
+    public ProxyRequest() {
+    }
+    
+    
+ 
+    public String getName() {
+        return name;
+    }
+    
+    public void setName(String name) {
+        this.name = name;
+    }
+    
+    
+    public boolean isValid() {
+        return StringUtils.isBlank(name);
+    }
+
+
+
+    public void addQueryParam(String paramName, String value) {
+        // TODO Auto-generated method stub
+        
+    }
+
+
+
+    public void addHeader(String headerName, String value) {
+        // TODO Auto-generated method stub
+        
+    }
+}

--- a/RESTProxy/src/test/java/com/example/proxy/ProxyTests.java
+++ b/RESTProxy/src/test/java/com/example/proxy/ProxyTests.java
@@ -1,0 +1,251 @@
+package com.example.proxy;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+import static org.junit.Assert.fail;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.client.RestTemplate;
+
+import com.example.proxy.dto.ProxyRequest;
+
+
+
+
+	@RunWith(SpringRunner.class)
+	@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+	public class ProxyTests {
+
+	    @LocalServerPort
+	    private int port = 0;
+
+	    private String proxyServiceURL;
+	    private String invalidProxyServiceURL;
+	    
+		private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+	  
+	   
+	   
+	    @Before
+	    public void init() throws Exception {
+	    	
+	    	StringBuilder baseURL = new StringBuilder();
+	    	baseURL.append("http://localhost:").append(port).append("/remoteservicegateway");
+	    	
+	    	invalidProxyServiceURL= baseURL.toString();
+            proxyServiceURL = baseURL.append("/proxyService").toString();
+            
+            
+	    }
+	    
+	    /**
+	     * Client error - malformed object sent to Proxy Service
+	     * e.g. object.name  not present
+	     * 
+	     * Expected response HTTP 400  (HTTP Bad Request) 
+	     */
+	    @Test
+	    public void testProxyPost400() {
+	    			
+	        logger.info("testProxyPost400: Client sent malformed message - madatory logical service name not present." );
+	    
+	        ProxyRequest proxyRequest = new ProxyRequest();
+	        proxyRequest.setName(null);            //  <- creates a malformed oproxyRequest object.
+	        
+	        
+	        ResponseEntity<?> proxyResponseEntity = null;
+
+	         
+	        try {
+	            RestTemplate restTemplate = new RestTemplate();
+	            proxyResponseEntity = restTemplate.exchange(proxyServiceURL,
+	            		HttpMethod.POST,
+	            		new HttpEntity<>(proxyRequest , createRESTHeaders() ),
+	            		ProxyRequest.class);
+            
+	            // should not get here.
+	            fail("testProxyPost400: Failed to detetect missing 'name' in proxy request");
+	                
+	        } catch (Exception e) {
+	           assertThat(proxyResponseEntity, is( notNullValue() ) );
+	           
+	           
+	           assertThat( proxyResponseEntity.getStatusCodeValue(), is(400) );
+	           assertThat(proxyResponseEntity.getStatusCode(), is(equalTo(HttpStatus.BAD_REQUEST)));
+	            
+	            
+    	      
+	        }
+
+	        ;
+	    }
+
+	    /**
+	     * Create the REST api headers. Used by the RESTTemplate
+	     * 
+	     * @return
+	     */
+	    public HttpHeaders createRESTHeaders() {
+	        HttpHeaders httpHeaders = new HttpHeaders();
+	        
+	        // Assumption: All proxy service invocations will be REST with a JSON body, also that some basic headers will be present.
+	        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+	        httpHeaders.add("Authorization", "Token abc123" );
+	        return httpHeaders;
+	    }
+
+        /**
+         * Client error - wrong Proxy Service url. 
+         * 
+         * e.g. Incorrect proxy service url 
+         * 
+         * Expected response HTTP 404  (HTTP NotFound) 
+         */
+        @Test
+        public void testProxyPost404() {
+        			
+            logger.info("testProxyPost404: Client sent to unknown proxy service." );
+     
+            
+            ResponseEntity<?> proxyResponseEntity = null;
+        
+             
+            try {
+                
+                // invoke the proxy service with unsupported endpoint url.
+                RestTemplate restTemplate = new RestTemplate();
+                proxyResponseEntity = restTemplate.exchange(invalidProxyServiceURL,
+                		HttpMethod.POST,
+                		new HttpEntity<>( new ProxyRequest() , createRESTHeaders() ),
+                		ProxyRequest.class);
+            
+                
+                
+                // should not get here.
+                fail("testProxyPost404: Failed test. Unexpected behaviour, ");
+                
+             
+                
+            } catch (Exception e) {
+                // Service located, but no valid end point mapping.
+                assertThat( e.getMessage(), containsString("404") );
+            }
+        
+            
+        }
+
+        /**
+         * 3rd Party URL invoked via  Proxy Service. 
+         * 
+         * 
+         * 
+         * Expected response HTTP 200  (HTTP OK) 
+         */
+        @Test
+        public void testProxyPost200() {
+        			
+            logger.info("testProxyPost200: 3rd Party URL invoked via  Proxy Service." );
+        
+            
+            ResponseEntity<?> proxyResponseEntity = null;
+            
+            // Create a typical client request
+            ProxyRequest proxyRequest = new ProxyRequest();
+            proxyRequest.setName("GetUser");
+            proxyRequest.addQueryParam("summary","true");
+//          proxyRequest.addPathParam("userId","1");        // Assumed that URL path param are out of scope of this example e.g. getUser/1?summary=true
+            proxyRequest.addHeader("abc","123");
+        
+             
+            try {
+                
+                // invoke the proxy service with unsupported endpoint url.
+                RestTemplate restTemplate = new RestTemplate();
+                proxyResponseEntity = restTemplate.exchange(proxyServiceURL,
+                		HttpMethod.POST,
+                		new HttpEntity<>( proxyRequest , createRESTHeaders() ),
+                		ProxyRequest.class);
+            
+                
+                
+                // Expected 3rd Party response code, seen from Proxy Service invocation.
+                assertThat( proxyResponseEntity.getStatusCodeValue(), is(equalTo(200)) );
+                
+             
+                
+            } catch (Exception e) {
+                
+                // should not get here.
+                fail("testProxyPost200: Failed test. Unexpected behaviour, ");
+                
+            }
+        
+            
+        }
+	    
+	    
+	    
+	    
+        
+        
+		/**
+		 * Save a action as expected.
+		 */
+//		@Test
+//		public void testActionPost200() {
+//					
+//		    String url = testHelper.createUnitTestActionURL(port, null);
+//		    Action savedAction = null;
+//		    Action newAction = Action.example();
+//		    newAction.setId(null);
+//		    
+//		    
+//		
+//		    RestTemplate restTemplate = new RestTemplate();
+//		
+//		     
+//		    try {
+//		        HttpEntity<Action> responseEntity = restTemplate.exchange(url,
+//		        		HttpMethod.POST,
+//		        		new HttpEntity<>(newAction, testHelper.createRESTHeaders(authToken) ),
+//		        		Action.class);
+//		
+//		        savedAction = responseEntity.getBody();
+//		
+//		        MediaType contentType = responseEntity.getHeaders().getContentType();
+//		        // application/json;charset=UTF-8
+//		        assertThat(StringUtils.equalsIgnoreCase(MediaType.APPLICATION_JSON_UTF8_VALUE, contentType.toString())).isTrue();
+//		        assertThat(StringUtils.isNotBlank(savedAction.getId()) ).isTrue();
+//		        logger.info(String.format("testActionPost200: Created a new action [%s]",savedAction.getId() ) );
+//		        
+//		    } catch (Exception e) {
+//		        fail("testActionPost200: Got excpetion " + e.getMessage());
+//		    }
+//		
+//		    
+//		}
+
+	
+		
+
+
+	}


### PR DESCRIPTION
I've added an initial outline of the controller so that I could create a
test. I've introduced the Hamcrest unit test syntax as I believe it makes
the test clearer to understand, also its semi self documenting in the
Junit console, when things may have broken.

I've also added Jacoco (code coverage tool) to determine test coverage.
I expect to revisit the tests as I mature the solution.

Updated README with Curlbased test results.
Showing a positive test case outcome, of POST'ing a small JSON proxy service request.
Being Http 200.