### PR TITLE
Added Proxy Request validation

### DIFF
--- a/RESTProxy/data/services.json
+++ b/RESTProxy/data/services.json
@@ -19,5 +19,19 @@
   	  "timeoutSeconds": 10,
   	    	  "staticHeaders" : [ {"Auth":"Token abcdefg"}],
   	  "staticQueryParams" : [{"sort":"desc"},{"pageSize":10}]
+  	  },
+  	  { "name":"EditUser",
+	  "method": "PUT",
+  	  "url" : { "protocol": "http", "host":"example.com", "path":"/users"},
+  	  "timeoutSeconds": 10,
+  	    	  "staticHeaders" : [ {"Auth":"Token abcdefg"}],
+  	  "staticQueryParams" : [{"sort":"desc"},{"pageSize":10}]
+  	  },
+  	  { "name":"EditUser",
+	  "method": "PUT",
+  	  "url" : { "protocol": "http", "host":"example.com", "path":"/users"},
+  	  "timeoutSeconds": 10,
+  	    	  "staticHeaders" : [ {"Auth":"Token abcdefg"}],
+  	  "staticQueryParams" : [{"sort":"desc"},{"pageSize":10}]
   	  }
 ]

--- a/RESTProxy/src/main/java/com/example/proxy/dto/ProxyRequest.java
+++ b/RESTProxy/src/main/java/com/example/proxy/dto/ProxyRequest.java
@@ -33,9 +33,17 @@ public class ProxyRequest {
         this.name = name;
     }
     
-    
+    /**
+     * Is the Proxy request valid.
+     * The proxy request logical service 'name' is seen as mandatory. 
+     * 
+     * other aspect of the request may also be checker for validity e.g. query parma Name / value pairs
+     * 
+     * @return boolean
+     */
     public boolean isValid() {
-        return StringUtils.isBlank(name);
+        // simply enforce that service name is mandatory.
+        return StringUtils.isNotBlank(name);
     }
 
 
@@ -50,5 +58,14 @@ public class ProxyRequest {
     public void addHeader(String headerName, String value) {
         // TODO Auto-generated method stub
         
+    }
+
+
+    /**
+     * Make the code easier to read.  Simply invert the isValid method. 
+     * @return boolean
+     */
+    public boolean isNotValid() {
+        return ! isValid();
     }
 }

--- a/RESTProxy/src/main/java/com/example/proxy/model/ServiceDefinition.java
+++ b/RESTProxy/src/main/java/com/example/proxy/model/ServiceDefinition.java
@@ -1,0 +1,48 @@
+package com.example.proxy.model;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection="services")
+public class ServiceDefinition {
+    @Id
+    private String id;
+    
+    private String name;
+    private String description;
+    
+    
+    public ServiceDefinition() {}
+
+
+    public String getId() {
+        return id;
+    }
+
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+
+    public String getName() {
+        return name;
+    }
+
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+    public String getDescription() {
+        return description;
+    }
+
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+    
+    
+}

--- a/RESTProxy/src/main/java/com/example/proxy/repository/ServiceRepository.java
+++ b/RESTProxy/src/main/java/com/example/proxy/repository/ServiceRepository.java
@@ -1,0 +1,12 @@
+package com.example.proxy.repository;
+
+import java.util.List;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import com.example.proxy.model.ServiceDefinition;
+
+public interface ServiceRepository extends MongoRepository<ServiceDefinition, String> {
+    // Get Service config where name = logical request Name (expect 1)
+    List<ServiceDefinition> findByName(String LogicalName);
+}

--- a/RESTProxy/src/test/java/com/example/proxy/ProxyTests.java
+++ b/RESTProxy/src/test/java/com/example/proxy/ProxyTests.java
@@ -1,11 +1,8 @@
 package com.example.proxy;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.notNullValue;
-
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.fail;
 
 import org.junit.Before;
@@ -19,233 +16,234 @@ import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 
 import com.example.proxy.dto.ProxyRequest;
 
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+public class ProxyTests {
 
+    @LocalServerPort
+    private int port = 0;
 
+    private String proxyServiceURL;
+    private String invalidProxyServiceURL;
 
-	@RunWith(SpringRunner.class)
-	@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-	public class ProxyTests {
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-	    @LocalServerPort
-	    private int port = 0;
+    @Before
+    public void init() throws Exception {
 
-	    private String proxyServiceURL;
-	    private String invalidProxyServiceURL;
-	    
-		private final Logger logger = LoggerFactory.getLogger(this.getClass());
+        StringBuilder baseURL = new StringBuilder();
+        baseURL.append("http://localhost:").append(port).append("/remoteservicegateway");
 
-	  
-	   
-	   
-	    @Before
-	    public void init() throws Exception {
-	    	
-	    	StringBuilder baseURL = new StringBuilder();
-	    	baseURL.append("http://localhost:").append(port).append("/remoteservicegateway");
-	    	
-	    	invalidProxyServiceURL= baseURL.toString();
-            proxyServiceURL = baseURL.append("/proxyService").toString();
-            
-            
-	    }
-	    
-	    /**
-	     * Client error - malformed object sent to Proxy Service
-	     * e.g. object.name  not present
-	     * 
-	     * Expected response HTTP 400  (HTTP Bad Request) 
-	     */
-	    @Test
-	    public void testProxyPost400() {
-	    			
-	        logger.info("testProxyPost400: Client sent malformed message - madatory logical service name not present." );
-	    
-	        ProxyRequest proxyRequest = new ProxyRequest();
-	        proxyRequest.setName(null);            //  <- creates a malformed oproxyRequest object.
-	        
-	        
-	        ResponseEntity<?> proxyResponseEntity = null;
+        invalidProxyServiceURL = baseURL.toString();
+        proxyServiceURL = baseURL.append("/proxyService").toString();
 
-	         
-	        try {
-	            RestTemplate restTemplate = new RestTemplate();
-	            proxyResponseEntity = restTemplate.exchange(proxyServiceURL,
-	            		HttpMethod.POST,
-	            		new HttpEntity<>(proxyRequest , createRESTHeaders() ),
-	            		ProxyRequest.class);
-            
-	            // should not get here.
-	            fail("testProxyPost400: Failed to detetect missing 'name' in proxy request");
-	                
-	        } catch (Exception e) {
-	           assertThat(proxyResponseEntity, is( notNullValue() ) );
-	           
-	           
-	           assertThat( proxyResponseEntity.getStatusCodeValue(), is(400) );
-	           assertThat(proxyResponseEntity.getStatusCode(), is(equalTo(HttpStatus.BAD_REQUEST)));
-	            
-	            
-    	      
-	        }
+    }
 
-	        ;
-	    }
+    /**
+     * Client error - malformed object sent to Proxy Service e.g. object.name not
+     * present
+     * 
+     * Expected response HTTP 400 (HTTP Bad Request)
+     */
+    @Test
+    public void testProxyPost400() {
 
-	    /**
-	     * Create the REST api headers. Used by the RESTTemplate
-	     * 
-	     * @return
-	     */
-	    public HttpHeaders createRESTHeaders() {
-	        HttpHeaders httpHeaders = new HttpHeaders();
-	        
-	        // Assumption: All proxy service invocations will be REST with a JSON body, also that some basic headers will be present.
-	        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
-	        httpHeaders.add("Authorization", "Token abc123" );
-	        return httpHeaders;
-	    }
+        logger.info("testProxyPost400: Client sent malformed message - madatory logical service name not present.");
 
-        /**
-         * Client error - wrong Proxy Service url. 
-         * 
-         * e.g. Incorrect proxy service url 
-         * 
-         * Expected response HTTP 404  (HTTP NotFound) 
-         */
-        @Test
-        public void testProxyPost404() {
-        			
-            logger.info("testProxyPost404: Client sent to unknown proxy service." );
-     
-            
-            ResponseEntity<?> proxyResponseEntity = null;
-        
-             
-            try {
-                
-                // invoke the proxy service with unsupported endpoint url.
-                RestTemplate restTemplate = new RestTemplate();
-                proxyResponseEntity = restTemplate.exchange(invalidProxyServiceURL,
-                		HttpMethod.POST,
-                		new HttpEntity<>( new ProxyRequest() , createRESTHeaders() ),
-                		ProxyRequest.class);
-            
-                
-                
-                // should not get here.
-                fail("testProxyPost404: Failed test. Unexpected behaviour, ");
-                
-             
-                
-            } catch (Exception e) {
-                // Service located, but no valid end point mapping.
-                assertThat( e.getMessage(), containsString("404") );
-            }
-        
-            
+        ProxyRequest proxyRequest = new ProxyRequest();
+        proxyRequest.setName(null); // <- creates a malformed oproxyRequest object.
+
+        ResponseEntity<?> proxyResponseEntity = null;
+
+        try {
+            RestTemplate restTemplate = new RestTemplate();
+            proxyResponseEntity = restTemplate.exchange(proxyServiceURL, HttpMethod.POST,
+                    new HttpEntity<>(proxyRequest, createRESTHeaders()), ProxyRequest.class);
+
+            // should not get here.
+            fail("testProxyPost400: Failed to detetect missing 'name' in proxy request");
+
+        } catch (HttpClientErrorException hsee) {
+            assertThat(hsee.getStatusCode().value(), is(equalTo(400)));
+
+        } catch (Exception e) {   
+            fail("testDuplicateLogicalService: Failed test. Unexpected Exception, ");
         }
 
-        /**
-         * 3rd Party URL invoked via  Proxy Service. 
-         * 
-         * 
-         * 
-         * Expected response HTTP 200  (HTTP OK) 
-         */
-        @Test
-        public void testProxyPost200() {
-        			
-            logger.info("testProxyPost200: 3rd Party URL invoked via  Proxy Service." );
-        
-            
-            ResponseEntity<?> proxyResponseEntity = null;
-            
-            // Create a typical client request
-            ProxyRequest proxyRequest = new ProxyRequest();
-            proxyRequest.setName("GetUser");
-            proxyRequest.addQueryParam("summary","true");
-//          proxyRequest.addPathParam("userId","1");        // Assumed that URL path param are out of scope of this example e.g. getUser/1?summary=true
-            proxyRequest.addHeader("abc","123");
-        
-             
-            try {
-                
-                // invoke the proxy service with unsupported endpoint url.
-                RestTemplate restTemplate = new RestTemplate();
-                proxyResponseEntity = restTemplate.exchange(proxyServiceURL,
-                		HttpMethod.POST,
-                		new HttpEntity<>( proxyRequest , createRESTHeaders() ),
-                		ProxyRequest.class);
-            
-                
-                
-                // Expected 3rd Party response code, seen from Proxy Service invocation.
-                assertThat( proxyResponseEntity.getStatusCodeValue(), is(equalTo(200)) );
-                
-             
-                
-            } catch (Exception e) {
-                
-                // should not get here.
-                fail("testProxyPost200: Failed test. Unexpected behaviour, ");
-                
-            }
-        
-            
+        ;
+    }
+
+    /**
+     * Create the REST api headers. Used by the RESTTemplate
+     * 
+     * @return
+     */
+    public HttpHeaders createRESTHeaders() {
+        HttpHeaders httpHeaders = new HttpHeaders();
+
+        // Assumption: All proxy service invocations will be REST with a JSON body, also
+        // that some basic headers will be present.
+        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+        httpHeaders.add("Authorization", "Token abc123");
+        return httpHeaders;
+    }
+
+    /**
+     * Client error - wrong Proxy Service url.
+     * 
+     * e.g. Incorrect proxy service url
+     * 
+     * Expected response HTTP 404 (HTTP NotFound)
+     */
+    @Test
+    public void testProxyPost404() {
+
+        logger.info("testProxyPost404: Client sent to unknown proxy service.");
+
+        ResponseEntity<?> proxyResponseEntity = null;
+
+        try {
+
+            // invoke the proxy service with unsupported endpoint url.
+            RestTemplate restTemplate = new RestTemplate();
+            proxyResponseEntity = restTemplate.exchange(invalidProxyServiceURL, HttpMethod.POST,
+                    new HttpEntity<>(new ProxyRequest(), createRESTHeaders()), ProxyRequest.class);
+
+            // should not get here.
+            fail("testProxyPost404: Failed test. Unexpected behaviour, ");
+
+        } catch (HttpClientErrorException hsee) {
+            assertThat(hsee.getStatusCode().value(), is(equalTo(404)));
+
+        } catch (Exception e) {   
+            fail("testDuplicateLogicalService: Failed test. Unexpected Exception, ");
         }
-	    
-	    
-	    
-	    
+
+    }
+
+    /**
+     * 3rd Party URL invoked via Proxy Service.
+     * 
+     * 
+     * 
+     * Expected response HTTP 200 (HTTP OK)
+     */
+    @Test
+    public void testProxyPost200() {
+
+        logger.info("testProxyPost200: 3rd Party URL invoked via  Proxy Service.");
+
+        ResponseEntity<?> proxyResponseEntity = null;
+
+        // Create a typical client request
+        ProxyRequest proxyRequest = new ProxyRequest();
+        proxyRequest.setName("GetUser");
+        proxyRequest.addQueryParam("summary", "true");
+//      proxyRequest.addPathParam("userId","1");        // Assumed that URL path param are out of scope of this example e.g. getUser/1?summary=true
+        proxyRequest.addHeader("abc", "123");
+
+        try {
+
+            // invoke the proxy service with unsupported endpoint url.
+            RestTemplate restTemplate = new RestTemplate();
+            proxyResponseEntity = restTemplate.exchange(proxyServiceURL, HttpMethod.POST,
+                    new HttpEntity<>(proxyRequest, createRESTHeaders()), ProxyRequest.class);
+
+            // Expected 3rd Party response code, seen from Proxy Service invocation.
+            assertThat(proxyResponseEntity.getStatusCodeValue(), is(equalTo(200)));
+
+        } catch (Exception e) {
+
+            // should not get here.
+            fail("testProxyPost200: Failed test. Unexpected behaviour, ");
+
+        }
+
+    }
+
+    /**
+     * Test for an unknown 3rd party service.
+     * 
+     * 
+     * 
+     * Expected response HTTP 400 (HTTP Bad Request)
+     */
+    @Test
+    public void testUnknownLogicalService() {
+
+        logger.info("testUnknownLogicalService: Try to invoke an unknown 3rd Party URL via  Proxy Service.");
+
+        ResponseEntity<?> proxyResponseEntity = null;
+
+        // Create a typical client request
+        ProxyRequest proxyRequest = new ProxyRequest();
+        proxyRequest.setName("GetUnDefinedLogicalService");     // <-- this has not been declare in the proxy service store...
         
+
+        try {
+
+            // invoke the proxy service with unsupported endpoint url.
+            RestTemplate restTemplate = new RestTemplate();
+            proxyResponseEntity = restTemplate.exchange(proxyServiceURL, HttpMethod.POST,
+                    new HttpEntity<>(proxyRequest, createRESTHeaders()), ProxyRequest.class);
+
+            // should not get here.
+            fail("testUnknownLogicalService: Failed test. Unexpected behaviour, ");
+        } catch (HttpClientErrorException hcee) {
+            assertThat(hcee.getStatusCode().value(), is(equalTo(400)));
+
+        } catch (Exception e) {   
+            fail("testDuplicateLogicalService: Failed test. Unexpected Exception, ");
+        }
+
+    }
+
+    /**
+     * Test for an duplicate logical service definition handling.
+     * 
+     * 
+     * 
+     * Expected response HTTP 500 (HTTP Bad Request)
+     */
+    @Test
+    public void testDuplicateLogicalService() {
+    
+        logger.info("testDuplicateLogicalService: Duplicates exist in the PRoxy cservice config.");
+    
+        ResponseEntity<?> proxyResponseEntity = null;
+    
+        // Create a typical client request
+        ProxyRequest proxyRequest = new ProxyRequest();
+        proxyRequest.setName("EditUser");     // <-- thisis duplicated within the proxy service store...
         
-		/**
-		 * Save a action as expected.
-		 */
-//		@Test
-//		public void testActionPost200() {
-//					
-//		    String url = testHelper.createUnitTestActionURL(port, null);
-//		    Action savedAction = null;
-//		    Action newAction = Action.example();
-//		    newAction.setId(null);
-//		    
-//		    
-//		
-//		    RestTemplate restTemplate = new RestTemplate();
-//		
-//		     
-//		    try {
-//		        HttpEntity<Action> responseEntity = restTemplate.exchange(url,
-//		        		HttpMethod.POST,
-//		        		new HttpEntity<>(newAction, testHelper.createRESTHeaders(authToken) ),
-//		        		Action.class);
-//		
-//		        savedAction = responseEntity.getBody();
-//		
-//		        MediaType contentType = responseEntity.getHeaders().getContentType();
-//		        // application/json;charset=UTF-8
-//		        assertThat(StringUtils.equalsIgnoreCase(MediaType.APPLICATION_JSON_UTF8_VALUE, contentType.toString())).isTrue();
-//		        assertThat(StringUtils.isNotBlank(savedAction.getId()) ).isTrue();
-//		        logger.info(String.format("testActionPost200: Created a new action [%s]",savedAction.getId() ) );
-//		        
-//		    } catch (Exception e) {
-//		        fail("testActionPost200: Got excpetion " + e.getMessage());
-//		    }
-//		
-//		    
-//		}
+    
+        try {
+    
+            // invoke the proxy service with unsupported endpoint url.
+            RestTemplate restTemplate = new RestTemplate();
+            proxyResponseEntity = restTemplate.exchange(proxyServiceURL, HttpMethod.POST,
+                    new HttpEntity<>(proxyRequest, createRESTHeaders()), ProxyRequest.class);
+    
+            // should not get here.
+            fail("testDuplicateLogicalService: Failed test. Unexpected behaviour, ");
+        } catch (HttpServerErrorException hsee) {
+            assertThat(hsee.getStatusCode().value(), is(equalTo(500)));
 
-	
-		
+        } catch (Exception e) {   
+            fail("testDuplicateLogicalService: Failed test. Unexpected Exception, ");
+        }
+    
+    }
 
+    
 
-	}
+}


### PR DESCRIPTION
This was achieved in 2 ways,
1. The 'Proxy Request' obj. structure is validated e.g. logical service name is mandatory
2. Logical Service name within the request obj. is lookedup agaist known definitions.
   If 0 is found then return Http 400
   If 1 is found then proceed with proxy service definition
   If >1 is found then down stream systems have introduce duplicates. Return Http 500.