### PR TITLE
Added the ProxyServiceClient to invoke remote API's.

### DIFF
--- a/RESTProxy/README.md
+++ b/RESTProxy/README.md
@@ -1,9 +1,24 @@
 # RESTProxy:
 
-A simple microservice to act as a proxy between internal microservices and external 3rd party API services. Where an internal service will create a logical service request object and POST this to the RESTProxy. A MongoDb 'services' collection is used to resolve the logical to physical service mapping, where additional static service details are recorded e.g. external 3rd party URL etc. The proxy will then invoke the external 3rd party service. The response being passed back to the internal client of this proxy, where they should mange the response. The assumption here is that this is a highly REST centric landscape. However the system could be extended to handle different message payload types (XML/SOAP or text) and transport implementations e.g. async RabbitMQ or Kafka service invocation passing back a correlation id upon the msg being published to the queue/topic.
+A simple microservice to act as a proxy between internal microservices and external 3rd party API services. 
+Where an internal service will POST a 'Proxy Request' object to the RESTProxy. 
+A MongoDb 'services' collection is used to resolve the logical to physical service mapping, where additional static service details are recorded e.g. external 3rd party URL etc. 
+The proxy will then invoke the external 3rd party service. 
+The response being passed back to the internal client as a 'Proxy Response' object.
+Where they should manage the response. A key features of the RESTProxy is that to add additional 
+3rd party API's - only the MongoDb ProxyConfig.services collection needs to be updated.
+
 
 ## Assumptions:
-This project uses a number of tools, understanding them at a high level should be sufficient to execute this service, following the developer instructions below. Being aware of Git, Docker, MongoDb/ MongoCompass, a REST test client (e.g. Postman) and Gradle build tool, would be an advantage.
+A few assumption about this service:
+
+1. This project uses a number of tools, understanding them at a high level should be sufficient to execute this service, following the developer instructions below. 
+   Being aware of Git, Docker, MongoDb/ MongoCompass and Gradle build tool, would be an advantage.
+2. The RESTProxy service does not currently support URL path parameter value requests 
+   (only query params)
+3. All services are REST/JSON based.
+4. In testing this service, it was helpful to have 3rd party api that supported CRUD 
+   operations to test the various HTTP operations.
 
 ## Get the example
 ```

--- a/RESTProxy/build.gradle
+++ b/RESTProxy/build.gradle
@@ -45,7 +45,9 @@ dependencies {
     compile('org.springframework.boot:spring-boot-starter-data-rest')
     testCompile('org.springframework.boot:spring-boot-starter-test')
 	
-
+	// httpclient -  used to override the default HTTPClient so that I can set the client side time out
+	compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5'
+    
     //some common useful things
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.5'
     compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'

--- a/RESTProxy/data/services.json
+++ b/RESTProxy/data/services.json
@@ -1,37 +1,46 @@
 [
-	{ "name":"GetUser",
-	  "method": "GET",
-  	  "url" : { "protocol": "http", "host":"example.com", "path":"/users"},
-  	  "timeoutSeconds": 10,
-  	  "staticHeaders" : [ {"Auth":"Token abcdefg"}],
-  	  "staticQueryParams" : [{"sort":"desc"},{"pageSize":10}]
-  	  },
-  	  { "name":"CreateUser",
-	  "method": "POST",
-  	  "url" : { "protocol": "http", "host":"example.com", "path":"/users"},
-  	  "timeoutSeconds": 10,
-  	    	  "staticHeaders" : [ {"Auth":"Token abcdefg"}],
-  	  "staticQueryParams" : [{"sort":"desc"},{"pageSize":10}]
-  	  },
-  	  { "name":"EditUser",
-	  "method": "PUT",
-  	  "url" : { "protocol": "http", "host":"example.com", "path":"/users"},
-  	  "timeoutSeconds": 10,
-  	    	  "staticHeaders" : [ {"Auth":"Token abcdefg"}],
-  	  "staticQueryParams" : [{"sort":"desc"},{"pageSize":10}]
-  	  },
-  	  { "name":"EditUser",
-	  "method": "PUT",
-  	  "url" : { "protocol": "http", "host":"example.com", "path":"/users"},
-  	  "timeoutSeconds": 10,
-  	    	  "staticHeaders" : [ {"Auth":"Token abcdefg"}],
-  	  "staticQueryParams" : [{"sort":"desc"},{"pageSize":10}]
-  	  },
-  	  { "name":"EditUser",
-	  "method": "PUT",
-  	  "url" : { "protocol": "http", "host":"example.com", "path":"/users"},
-  	  "timeoutSeconds": 10,
-  	    	  "staticHeaders" : [ {"Auth":"Token abcdefg"}],
-  	  "staticQueryParams" : [{"sort":"desc"},{"pageSize":10}]
-  	  }
+	{
+		"name": "GetUser",
+		"description": "A test service I declared to satisfy a +ve Http200 test outcome",
+		"method": "GET",
+		"url": "http://localhost:8081/StarQuake/security/api/v1/zone/",
+		"timeoutSeconds": 10,
+		"staticHeaders": [
+			{
+				"Authorization": "Token Token eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJnYXZpbiJ9.QymCSv_p-MFgROGkSxAnHts7BTxEtzcgCur3hIffCqg"
+			}
+		]
+	},
+	{
+		"name": "GetUserTimeOut",
+		"description": "A test service I declared to satisfy a Http502 test outcome, based on remote client (sleeps 45sec)",
+		"method": "GET",
+		"url": "http://localhost:8081/StarQuake/security/api/v1/policies/",
+		"timeoutSeconds": 10
+	},
+	{
+		"name": "EditUserDuplicate",
+		"description": "A Test service which fails Rest Proxy validation HTTP400, due to dulicate enties in this config.",
+		"method": "PUT",
+		"url": "http://example.com/users",
+		"timeoutSeconds": 10,
+		"staticHeaders": [
+			{
+				"Auth": "Token abcdefg"
+			}
+		]
+	},
+	{
+		"name": "EditUserDuplicate",
+		"description": "A Test service which fails Rest Proxy validation Http 400, due to dulicate enties in this config.",
+		"method": "PUT",
+		"url": "http://example.com/users",
+		"timeoutSeconds": 10
+	},
+	{
+		"name": "FakeApi",
+		"description": "A test service I declared to satisfy a +ve Http404 test outcome",
+		"method": "Get",
+		"url": "http://doesnotexist.com/fake"
+	}
 ]

--- a/RESTProxy/src/main/java/com/example/proxy/dto/Header.java
+++ b/RESTProxy/src/main/java/com/example/proxy/dto/Header.java
@@ -1,0 +1,43 @@
+package com.example.proxy.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Header {
+
+    @JsonProperty
+    private String name;
+
+    @JsonProperty
+    private String value;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public Header() {};
+    
+    public Header(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    @JsonIgnore
+    @Override
+    public String toString() {
+        return String.format("%s: %s", name, value);
+    }
+
+}

--- a/RESTProxy/src/main/java/com/example/proxy/dto/ProxyRequest.java
+++ b/RESTProxy/src/main/java/com/example/proxy/dto/ProxyRequest.java
@@ -1,71 +1,124 @@
 package com.example.proxy.dto;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.commons.lang3.StringUtils;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * A simple Proxy service request Object.
  * 
- * A logical request object containing details of the request to be relayed onto the remote 3rd party service.
+ * A logical request object containing details of the request to be relayed onto
+ * the remote 3rd party service.
  * 
  * 
  * @author gavinling
  *
  */
 public class ProxyRequest {
-    // Mandatory: logical proxy service name.  Resolves to persistent service profile.
+    // Mandatory: logical proxy service name. Resolves to persistent service
+    // profile.
+    @JsonProperty
     private String name;
-    
-    // Optional: request object properties
-//    private ArrayList<header> headers = new ArrayList<>();
-//    private ArrayList<Queryparam> queryParams = new ArrayList<>();
-//    private String payload;
+    @JsonProperty
+    private String method;
 
-    public ProxyRequest() {
-    }
+    // Optional: request object properties
+    @JsonProperty
+    private List<Header> headers = new ArrayList<>();
+    
+    @JsonProperty
+    private Map<String, String> qparam = new HashMap<>();
+    
+    @JsonProperty
+    private String payload;
+
     
     
- 
+    
+    
+    
+    public ProxyRequest() {}
+
     public String getName() {
         return name;
     }
-    
+
     public void setName(String name) {
         this.name = name;
     }
-    
+
+    public String getMethod() {
+        return method;
+    }
+
+    public void setMethod(String method) {
+        this.method = method;
+    }
+
+    public List<Header> getHeaders() {
+        return headers;
+    }
+
+    public void setHeaders(List<Header> headers) {
+        this.headers = headers;
+    }
+
+    public Map<String, String> getQparam() {
+        return qparam;
+    }
+
+    public void setQparam(Map<String, String> qparam) {
+        this.qparam = qparam;
+    }
+
+    public String getPayload() {
+        return payload;
+    }
+
+    public void setPayload(String payload) {
+        this.payload = payload;
+    }
+
     /**
-     * Is the Proxy request valid.
-     * The proxy request logical service 'name' is seen as mandatory. 
+     * Is the Proxy request valid. The proxy request logical service 'name' is seen
+     * as mandatory.
      * 
-     * other aspect of the request may also be checker for validity e.g. query parma Name / value pairs
+     * other aspect of the request may also be checker for validity e.g. query parma
+     * Name / value pairs
      * 
      * @return boolean
      */
+    @JsonIgnore
     public boolean isValid() {
         // simply enforce that service name is mandatory.
         return StringUtils.isNotBlank(name);
     }
 
-
-
+    @JsonIgnore
     public void addQueryParam(String paramName, String value) {
         // TODO Auto-generated method stub
-        
+
     }
 
-
-
+    @JsonIgnore
     public void addHeader(String headerName, String value) {
         // TODO Auto-generated method stub
-        
+
     }
 
-
     /**
-     * Make the code easier to read.  Simply invert the isValid method. 
+     * Make the code easier to read. Simply invert the isValid method.
+     * 
      * @return boolean
      */
+    @JsonIgnore
     public boolean isNotValid() {
-        return ! isValid();
+        return !isValid();
     }
 }

--- a/RESTProxy/src/main/java/com/example/proxy/dto/ProxyResponse.java
+++ b/RESTProxy/src/main/java/com/example/proxy/dto/ProxyResponse.java
@@ -1,0 +1,62 @@
+package com.example.proxy.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * A simple Proxy service response Object.
+ * 
+ * An object containing details of the 3rd party service response
+ * 
+ * 
+ * @author gavinling
+ *
+ */
+public class ProxyResponse {
+
+    @JsonProperty
+    private String body;
+
+    @JsonProperty
+    private List<Header> headers = new ArrayList<Header>();
+
+    
+    public ProxyResponse() {}
+    
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public List<Header> getHeaders() {
+        return headers;
+    }
+
+    public void setHeaders(List<Header> headers) {
+        this.headers = headers;
+    }
+
+    
+
+    // A Request/Response may contain duplicate Headers so store as simple list of
+    // k,v.s
+    @JsonIgnore
+    public void addHeader(String name, String value) {
+        headers.add(new Header(name, value));
+    }
+
+    @JsonIgnore
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        headers.forEach(header -> sb.append(header.toString()).append("  ,"));
+        sb.append(body);
+        return sb.toString();
+    }
+}

--- a/RESTProxy/src/main/java/com/example/proxy/model/ServiceDefinition.java
+++ b/RESTProxy/src/main/java/com/example/proxy/model/ServiceDefinition.java
@@ -1,7 +1,12 @@
 package com.example.proxy.model;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
+
+import com.example.proxy.dto.Header;
 
 @Document(collection="services")
 public class ServiceDefinition {
@@ -9,8 +14,11 @@ public class ServiceDefinition {
     private String id;
     
     private String name;
-    private String description;
-    
+    private String description ="";
+    private String url;
+    private String method;
+    private List<Header> staticHeaders = new ArrayList<>();
+    private int timeoutSeconds = 20;    // Default 20 second remote srive synch. timeout (onRead) if not declared in Store 
     
     public ServiceDefinition() {}
 
@@ -43,6 +51,48 @@ public class ServiceDefinition {
     public void setDescription(String description) {
         this.description = description;
     }
+
+    
+    public String getUrl() {
+        return url;
+    }
+
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+
+    public String getMethod() {
+        return method;
+    }
+
+
+    public void setMethod(String method) {
+        this.method = method;
+    }
+
+
+    public List<Header> getStaticHeaders() {
+        return staticHeaders;
+    }
+
+
+    public void setStaticHeaders(List<Header> staticHeaders) {
+        this.staticHeaders = staticHeaders;
+    }
+
+
+    public int getTimeoutSeconds() {
+        return timeoutSeconds;
+    }
+
+
+    public void setTimeoutSeconds(int timeoutSeconds) {
+        this.timeoutSeconds = timeoutSeconds;
+    }
+
+    
     
     
 }

--- a/RESTProxy/src/main/java/com/example/proxy/service/ProxyServiceClient.java
+++ b/RESTProxy/src/main/java/com/example/proxy/service/ProxyServiceClient.java
@@ -1,0 +1,120 @@
+package com.example.proxy.service;
+
+
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.forwardedUrl;
+
+import org.apache.commons.lang3.StringUtils;
+import org.mockito.internal.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.example.proxy.dto.ProxyRequest;
+import com.example.proxy.dto.ProxyResponse;
+import com.example.proxy.model.ServiceDefinition;
+
+@Service
+public class ProxyServiceClient {
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    public ProxyResponse invokeRemote(ProxyRequest proxyRequest, ServiceDefinition serviceDefinition) {
+        ProxyResponse proxyResponse = new ProxyResponse();
+
+        // Form the URL from the Service Definition & Request Query Parameters
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(serviceDefinition.getUrl());
+        if (!proxyRequest.getQparam().isEmpty()) {
+            proxyRequest.getQparam().forEach((k, v) -> {
+                // prevent adding badly formed QueryParams
+                if( StringUtils.isNotBlank(v)) {
+                    uriBuilder.queryParam(k, v);
+                }
+            });
+        }
+        
+        String     remoteURL        = uriBuilder.toUriString();
+        HttpMethod remoteHttpMethod = HttpMethod.resolve(serviceDefinition.getMethod());
+        
+        
+        // Establish request Body (JSON String) when POST/PUT   (Not required for GET/DELETE)
+        String     remotePayLoad;
+        if (remoteHttpMethod==HttpMethod.POST || remoteHttpMethod==HttpMethod.PUT) {
+            remotePayLoad  = proxyRequest.getPayload();
+            
+        } else {
+            remotePayLoad  = "";
+            
+        }
+        
+        
+        
+        
+
+        try {
+            // Set the Rest Temple sync. Timeout, based on the Service config value...
+            // This is a highly troubled area in Spring, many different version of doing this over time...
+            // Basically it boils down to '...Spring does not expose convenient setters for Timeout...', so you have
+            // to dig around in the underlying Sender, Sender Factory, RequestConfig etc. Or delegate to
+            // Apache HttpClient - which is what I have done by introducing HttpClient into Gradle dependencies.
+            HttpComponentsClientHttpRequestFactory httpRequestFactory = new HttpComponentsClientHttpRequestFactory();
+            httpRequestFactory.setConnectTimeout( 10000);           // allow for slow infrastructure
+            httpRequestFactory.setReadTimeout( 2000);               // allow for slow remote service response
+            httpRequestFactory.setConnectionRequestTimeout(60000);  // allow for this RESTProxy connection manager being 'busy'
+            RestTemplate restTemplate = new RestTemplate(httpRequestFactory);
+            
+           
+            
+            // Add Default Headers (JSON) and those from serviceDef. &Request 
+            HttpHeaders remoteHeaders = new HttpHeaders();
+            remoteHeaders.setContentType(MediaType.APPLICATION_JSON);
+            if( ! proxyRequest.getHeaders().isEmpty()) {
+                // prevent form adding badly form Header defs.
+                proxyRequest.getHeaders().forEach( h -> {
+                    if (StringUtils.isNotBlank(h.getName())) {
+                        remoteHeaders.add(h.getName(), h.getValue());
+                    }
+                });
+            }
+            if( ! serviceDefinition.getStaticHeaders().isEmpty()) {
+                serviceDefinition.getStaticHeaders().forEach( h -> {
+                    // prevent form adding badly form Header defs.
+                    if (StringUtils.isNotBlank(h.getName())) {
+                        remoteHeaders.add(h.getName(), h.getValue());
+                    }
+                });
+            }
+            // Build the Remote Request (3rd Party API) request& response Entity.
+            HttpEntity<String> requestEntity = new HttpEntity<String>(remotePayLoad, remoteHeaders);
+            HttpEntity<String> response = null;
+            
+
+            logger.warn(String.format(">>>> Invoking Remote 3rd party API [%s] %s:  %s",proxyRequest.getName(), remoteHttpMethod, remoteURL));
+            response = restTemplate.exchange(remoteURL, 
+                                             remoteHttpMethod, 
+                                             requestEntity,
+                                             String.class);
+            logger.warn(String.format("<<<<< Response from Remote 3rd party API [%s]", proxyRequest.getName() ) );
+            
+
+
+            // unpack the Http Headers MultiValueMap - into a simple list of Key values. 
+            response.getHeaders().forEach((k, v) -> {
+                v.forEach(value -> proxyResponse.addHeader(k, value));
+            });
+            proxyResponse.setBody(response.getBody());
+
+            return proxyResponse;
+
+        } catch (Throwable t) {
+            throw new RemoteInvocationException(t.getMessage());
+        }
+    }
+
+}

--- a/RESTProxy/src/main/java/com/example/proxy/service/RemoteInvocationException.java
+++ b/RESTProxy/src/main/java/com/example/proxy/service/RemoteInvocationException.java
@@ -1,0 +1,29 @@
+package com.example.proxy.service;
+
+public class RemoteInvocationException extends RuntimeException {
+
+    public RemoteInvocationException() {
+        // TODO Auto-generated constructor stub
+    }
+
+    public RemoteInvocationException(String message) {
+        super(message);
+        
+    }
+
+    public RemoteInvocationException(Throwable cause) {
+        super(cause);
+            }
+
+    public RemoteInvocationException(String message, Throwable cause) {
+        super(message, cause);
+        
+    }
+
+    public RemoteInvocationException(String message, Throwable cause, boolean enableSuppression,
+            boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+        
+    }
+
+}


### PR DESCRIPTION
In doing this I made the assumption that the REST Proxy will respond to the
internal clients via a 'ProxyResponse.java' object, containing the results
of the Remote 3rd part API call. A few issues to consider here. Http Headers
can contain duplicates, which make this area overly complex.
Another area of concern is associated with Synch. Service Timeout. You don't want
to wait forever, you may also need to account for 3rd party performance. So
it seemed sensible to provide a timeout value per service. The issue here
is that this timeout can be one of 3 different points along the invocation process.
I've opted to set the timeout, waiting for the remote service to start streaming
bytes back along the wire. Not attempting to make the initial connection.
Historically setting a webservice timeout in Spring is fiddly. I chose to
leverage Apache HTTP Client as a dependancy to the project.

I did consider creating a test for the timeout handling of Remote 3rd part
API, but that was to tricky outside of my setup. Where I have a number of
REST CRUD apis to tinker with.

Additional work is required to unmarshell Headers and QParams from the
ProxyRequest JSON and the MongoDb. I believe the injected JSON and POJO
code needs a small change to make that work correctly.